### PR TITLE
feat: 新增 conf-papers 顶会论文搜索推荐技能

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@
 
 这是一套 Claude Code 技能（Skills）集合，用于自动化研究论文的搜索、推荐、分析和整理工作流。通过调用 arXiv 和 Semantic Scholar API，每天为你推荐高质量论文，并自动生成详细笔记和关系图谱。
 
+## 更新日志
+
+| 日期 | 版本 | 更新内容 |
+|------|------|----------|
+| 2024-03-13 | v1.1 | 新增 `conf-papers` 技能：支持搜索 CVPR/ICCV/ECCV/ICLR/AAAI/NeurIPS/ICML 等顶级会议论文，基于 DBLP + Semantic Scholar 双数据源，独立配置文件，三维评分推荐 |
+| 2024-03-01 | v1.0 | 初始版本：start-my-day 每日推荐、paper-analyze 论文分析、extract-paper-images 图片提取、paper-search 论文搜索 |
+
 ## 功能特点
 
 ### 1. start-my-day - 每日论文推荐
@@ -39,6 +46,13 @@
 - 在已有笔记中搜索论文
 - 支持按标题、作者、关键词、领域搜索
 - 相关性评分排序
+
+### 5. conf-papers - 顶会论文搜索推荐
+- 搜索 CVPR/ICCV/ECCV/ICLR/AAAI/NeurIPS/ICML 等顶级会议论文
+- 基于 DBLP API 获取论文列表 + Semantic Scholar 补充引用和摘要
+- 独立配置文件 `conf-papers.yaml`（关键词、排除词、默认年份/会议）
+- 两阶段过滤：标题关键词轻量筛选 → S2 补充 → 三维评分（相关性 40% + 热门度 40% + 质量 20%）
+- 前三篇论文自动生成详细分析（需有 arXiv ID）
 
 ## 安装
 
@@ -231,8 +245,13 @@ evil-read-arxiv/
 │   ├── skill.md
 │   └── scripts/
 │       └── extract_images.py # 图片提取脚本
-└── paper-search/             # 论文搜索技能
-    └── skill.md
+├── paper-search/             # 论文搜索技能
+│   └── skill.md
+└── conf-papers/              # 顶会论文搜索推荐技能
+    ├── SKILL.md              # 技能定义文件
+    ├── conf-papers.yaml      # 独立配置（关键词、会议、年份）
+    └── scripts/
+        └── search_conf_papers.py  # DBLP搜索 + S2补充 + 评分
 ```
 
 ## 评分机制

--- a/conf-papers/SKILL.md
+++ b/conf-papers/SKILL.md
@@ -1,0 +1,372 @@
+---
+name: conf-papers
+description: 顶级会议论文搜索推荐 - 搜索 CVPR/ICCV/ECCV/ICLR/AAAI/NeurIPS/ICML 等顶会论文
+---
+You are the Conference Paper Recommender for OrbitOS.
+
+# 目标
+帮助用户搜索顶级学术会议（CVPR/ICCV/ECCV/ICLR/AAAI/NeurIPS/ICML）中与研究兴趣相关的论文，按年份筛选，生成推荐笔记到 Obsidian vault。
+
+# 工作流程
+
+## 工作流程概述
+
+本 skill 使用 DBLP API 搜索会议论文列表，通过 Semantic Scholar API 补充引用数和摘要，然后基于相关性、热门度、质量三个维度评分排序，生成推荐笔记。
+
+## 配置说明
+
+本 skill 使用独立配置文件 `conf-papers.yaml`（位于 skill 目录下），与 start-my-day 的 `research_interests.yaml` 完全独立：
+
+```yaml
+# conf-papers.yaml
+keywords:           # 感兴趣的关键词（用于筛选论文标题）
+  - "large language model"
+  - "LLM"
+  - ...
+excluded_keywords:  # 排除的关键词
+  - "3D"
+  - "survey"
+  - ...
+default_year: 2024           # 默认搜索年份
+default_conferences:         # 默认搜索会议
+  - "ICLR"
+  - "NeurIPS"
+  - ...
+top_n: 10                    # 返回论文数量
+```
+
+命令行参数（年份、会议）可以覆盖配置中的默认值。如果命令行没有指定，则使用配置文件中的值。
+
+## 步骤1：解析参数
+
+1. **提取年份**（可选，默认从配置读取）
+   - 从用户输入中提取年份，如 `/conf-papers 2025`
+   - 未指定时使用配置中的 `conf_papers.default_year`
+
+2. **提取会议名**（可选，默认从配置读取）
+   - 用户可以指定会议，如 `/conf-papers 2025 ICLR,CVPR`
+   - 未指定时使用配置中的 `conf_papers.default_conferences`
+   - 注意：ICCV 在偶数年、ECCV 在奇数年可能无结果（双年会议），正常跳过
+
+## 步骤2：扫描已有笔记构建索引
+
+复用 `start-my-day` 的扫描脚本：
+
+```bash
+cd "$SKILL_DIR/../start-my-day"
+python scripts/scan_existing_notes.py \
+  --vault "$OBSIDIAN_VAULT_PATH" \
+  --output "$SKILL_DIR/existing_notes_index.json"
+```
+
+## 步骤3：搜索顶会论文
+
+使用 `scripts/search_conf_papers.py` 完成搜索、补充和评分：
+
+```bash
+cd "$SKILL_DIR"
+python scripts/search_conf_papers.py \
+  --config "$SKILL_DIR/conf-papers.yaml" \
+  --output conf_papers_filtered.json \
+  --year {年份} \
+  --conferences "{会议列表，逗号分隔}"
+```
+
+> 注意：`--config` 默认指向 skill 目录下的 `conf-papers.yaml`，通常不需要手动指定。`--year` 和 `--conferences` 未指定时使用配置文件中的默认值。
+
+**脚本工作流**：
+1. **DBLP 搜索**：调用 DBLP API 获取指定会议和年份的全部论文
+2. **轻量过滤**：凭标题关键词匹配研究兴趣，大幅缩小范围（~200篇）
+3. **S2 补充**：仅对过滤后的论文查询 Semantic Scholar，获取摘要和引用数
+4. **三维评分**：相关性(40%) + 热门度(40%) + 质量(20%)，排序取 top N
+
+**评分说明**（与 start-my-day 的区别：无新近性维度，因为年份由用户指定）：
+
+```yaml
+推荐评分 =
+  相关性评分: 40%   # 与研究兴趣的匹配程度
+  热门度评分: 40%   # 基于引用数（influentialCitationCount 优先）
+  质量评分: 20%     # 从摘要推断创新性和实验质量
+```
+
+## 步骤4：读取筛选结果
+
+从 `conf_papers_filtered.json` 中读取结果：
+
+```bash
+cat conf_papers_filtered.json
+```
+
+**结果包含**：
+- `year`: 搜索年份
+- `conferences_searched`: 搜索的会议列表
+- `total_found`: DBLP 搜索到的总论文数
+- `total_filtered`: 关键词过滤后的论文数
+- `total_enriched`: S2 补充成功的论文数
+- `top_papers`: 前 N 篇高评分论文，每篇包含：
+  - title, authors, conference, year
+  - dblp_url, arxiv_id（如有）
+  - abstract, citationCount, influentialCitationCount
+  - scores（relevance, popularity, quality, recommendation）
+  - matched_domain, matched_keywords
+
+## 步骤5：生成推荐笔记
+
+### 5.1 创建推荐笔记文件
+
+- 文件名：`10_Daily/{年份}_顶会论文推荐.md`
+- frontmatter:
+  ```yaml
+  ---
+  keywords: [关键词1, 关键词2, ...]
+  tags: ["llm-generated", "conf-paper-recommend"]
+  ---
+  ```
+
+### 5.2 推荐笔记结构
+
+#### 概览部分
+
+```markdown
+## {年份} 顶会论文推荐概览
+
+本次从 **{会议列表}** 中共搜索到 {total_found} 篇论文，经过研究兴趣匹配筛选出 {total_filtered} 篇候选，最终推荐以下 {top_n} 篇高质量论文。
+
+- **总体趋势**：{总结论文的整体研究趋势}
+
+- **研究热点**：
+  - **{热点1}**：{简要描述}
+  - **{热点2}**：{简要描述}
+  - **{热点3}**：{简要描述}
+
+- **阅读建议**：{给出阅读顺序建议}
+```
+
+#### 论文列表（统一格式，按评分排序）
+
+```markdown
+### [[论文名字]]
+- **作者**：[作者列表]
+- **会议**：{CVPR/ICLR/...} {年份}
+- **引用**：{citationCount} (influential: {influentialCitationCount})
+- **链接**：[DBLP](链接) | [arXiv](链接) | [PDF](链接)
+- **笔记**：[[已有笔记路径]] 或 <<无>>
+
+**一句话总结**：[一句话概括论文的核心贡献]
+
+**核心贡献/观点**：
+- [贡献点1]
+- [贡献点2]
+- [贡献点3]
+
+**关键结果**：[从摘要中提取的最重要结果]
+
+---
+```
+
+**链接规则**：
+- 有 arXiv ID 的论文：提供 arXiv 和 PDF 链接
+- 无 arXiv ID 的论文：仅提供 DBLP 链接，标注"无 arXiv 版本"
+- 有 DOI 的论文：额外提供 DOI 链接
+
+### 5.3 前 3 篇特殊处理
+
+对于前 3 篇论文（评分最高的 3 篇）：
+
+**步骤0：检查论文是否已有笔记**
+```bash
+# 在 20_Research/Papers/ 目录中搜索已有笔记
+# 搜索方式：
+# 1. 按论文ID搜索（如 2501.12345）
+# 2. 按论文标题搜索（模糊匹配）
+```
+
+**步骤1：根据检查结果决定处理方式**
+
+如果已有笔记：
+- 不生成新的详细报告
+- 使用已有笔记路径作为 wikilink
+- 在推荐笔记的"详细报告"字段引用已有笔记
+
+如果没有笔记 **且** 论文有 arXiv ID：
+- 调用 `extract-paper-images` 提取图片
+- 调用 `paper-analyze` 生成详细报告
+- 在推荐笔记中添加图片和详细报告链接
+
+如果没有笔记 **且** 论文无 arXiv ID：
+- 标注"无 arXiv 版本，无法自动提取图片和生成详细分析"
+- 提供 DBLP/DOI 链接供手动查阅
+- 跳过图片提取和深度分析
+
+**步骤2：在推荐笔记中插入图片和链接**
+
+有 arXiv ID + 有图片：
+```markdown
+### [[论文名字]]
+- **作者**：[作者列表]
+- **会议**：{会议} {年份}
+- **引用**：{citationCount} (influential: {influentialCitationCount})
+- **链接**：[DBLP](链接) | [arXiv](链接) | [PDF](链接)
+- **详细报告**：[[详细报告路径]] (自动生成)
+
+**一句话总结**：[一句话概括论文的核心贡献]
+
+![论文图片|600](图片路径)
+
+**核心贡献/观点**：
+...
+```
+
+无 arXiv ID：
+```markdown
+### [[论文名字]]
+- **作者**：[作者列表]
+- **会议**：{会议} {年份}
+- **引用**：{citationCount} (influential: {influentialCitationCount})
+- **链接**：[DBLP](链接)
+- **备注**：无 arXiv 版本，无法自动提取图片
+
+**一句话总结**：[一句话概括论文的核心贡献]
+
+**核心贡献/观点**：
+...
+```
+
+## 步骤6：关键词链接
+
+复用 `start-my-day` 的关键词链接脚本：
+
+```bash
+cd "$SKILL_DIR/../start-my-day"
+python scripts/link_keywords.py \
+  --index "$SKILL_DIR/existing_notes_index.json" \
+  --input "$OBSIDIAN_VAULT_PATH/10_Daily/{年份}_顶会论文推荐.md" \
+  --output "$OBSIDIAN_VAULT_PATH/10_Daily/{年份}_顶会论文推荐.md"
+```
+
+# 重要规则
+
+- **年份为必需参数**：用户必须指定搜索年份
+- **三维评分**：相关性(40%) + 热门度(40%) + 质量(20%)，无新近性维度
+- **文件名以年份**：`10_Daily/{年份}_顶会论文推荐.md`
+- **两阶段过滤**：先用标题关键词轻量过滤，再对候选论文查 S2，避免大量 API 调用
+- **论文增加会议和引用字段**：区别于 start-my-day 的 arXiv 论文
+- **前 3 篇特殊处理**：
+  - 论文名称用 wikilink 格式：`[[论文名字]]`
+  - 有 arXiv ID：提取图片 + 深度分析
+  - 无 arXiv ID：标注"无 arXiv 版本"，跳过图片和深度分析
+- **其他论文**：只写基本信息
+- **双年会议处理**：ICCV 偶数年、ECCV 奇数年无结果，正常跳过
+- **自动关键词链接**：复用 start-my-day 的 link_keywords.py
+
+# 错误处理
+
+| 场景 | 处理 |
+|------|------|
+| DBLP 请求失败 | 3 次重试 + 指数退避，单会议失败不中断整体 |
+| S2 429 限流 | 等待 30 秒重试 |
+| S2 补充失败 | 保留论文，abstract=None, citationCount=0，仅凭标题评分 |
+| 双年会议空结果 | ICCV 偶数年、ECCV 奇数年无结果，正常跳过并记录日志 |
+| 论文无 arXiv ID | 跳过图片提取和深度分析，标注在笔记中 |
+
+# 与其他 skills 的区别
+
+## conf-papers (本skill)
+- **目的**：搜索顶级会议论文，按年份推荐
+- **数据源**：DBLP + Semantic Scholar
+- **搜索范围**：指定年份的指定会议
+- **评分维度**：相关性 + 热门度 + 质量（无新近性）
+- **输出**：年度推荐笔记
+
+## start-my-day (每日推荐)
+- **目的**：每日 arXiv 新论文推荐
+- **数据源**：arXiv + Semantic Scholar
+- **搜索范围**：近一个月 + 近一年热门论文
+- **评分维度**：相关性 + 新近性 + 热门度 + 质量
+- **输出**：每日推荐笔记
+
+# 使用说明
+
+当用户输入 `/conf-papers` 时，按以下步骤执行：
+
+**参数支持**：
+- 可选：年份（如 `2025`），未指定时使用配置中的 `conf_papers.default_year`
+- 可选：会议名（如 `ICLR,CVPR`，逗号分隔），未指定时使用配置中的 `conf_papers.default_conferences`
+- 搜索关键词和排除关键词均从 `conf_papers` 配置段读取
+- 示例：
+  - `/conf-papers` — 使用配置中的默认年份和会议
+  - `/conf-papers 2025` — 搜索配置中默认会议的 2025 年论文
+  - `/conf-papers 2024 ICLR` — 仅搜索 ICLR 2024
+  - `/conf-papers 2024 CVPR,NeurIPS` — 搜索 CVPR 和 NeurIPS 2024
+
+## 自动执行流程
+
+1. **解析参数**
+   - 提取年份和可选会议名
+   - 验证会议名是否在支持列表中
+
+2. **扫描现有笔记构建索引**
+   ```bash
+   cd "$SKILL_DIR/../start-my-day"
+   python scripts/scan_existing_notes.py \
+     --vault "$OBSIDIAN_VAULT_PATH" \
+     --output "$SKILL_DIR/existing_notes_index.json"
+   ```
+
+3. **搜索和筛选顶会论文**
+   ```bash
+   cd "$SKILL_DIR"
+   python scripts/search_conf_papers.py \
+     --config "$SKILL_DIR/conf-papers.yaml" \
+     --output conf_papers_filtered.json \
+     --year {年份} \
+     --conferences "{会议列表}" \
+     --top-n 10
+   ```
+
+4. **读取筛选结果**
+   - 从 `conf_papers_filtered.json` 中读取
+   - 获取前 10 篇高评分论文
+
+5. **生成推荐笔记（包含关键词链接）**
+   - 创建 `10_Daily/{年份}_顶会论文推荐.md`
+   - 按评分排序
+   - 前 3 篇特殊处理：图片 + 深度分析（仅有 arXiv ID 的论文）
+   - 其他论文只写基本信息
+   - 自动关键词链接
+
+6. **对前 3 篇论文执行深度分析**（仅有 arXiv ID 的论文）
+   ```bash
+   # 对每篇前三论文执行以下操作
+
+   # 步骤1：检查论文是否已有笔记
+   # 在 20_Research/Papers/ 目录中搜索
+
+   # 步骤2：根据检查结果决定处理方式
+   if 已有笔记:
+       # 不生成新的详细报告
+       # 使用已有的笔记路径
+   elif 有 arXiv ID:
+       # 提取第一张图片
+       /extract-paper-images [论文ID]
+       # 生成详细分析报告
+       /paper-analyze [论文ID]
+   else:
+       # 无 arXiv ID，跳过深度分析
+       # 标注在推荐笔记中
+   ```
+
+## 临时文件清理
+
+- `conf_papers_filtered.json` — 搜索结果
+- `existing_notes_index.json` — 笔记索引
+- 推荐笔记已保存到 vault 后，可清理临时文件
+
+## 依赖项
+
+- Python 3.x
+- PyYAML
+- 网络连接（DBLP API + Semantic Scholar API）
+- `start-my-day` skill（复用 scan_existing_notes.py, link_keywords.py, search_arxiv.py 的评分函数）
+- `extract-paper-images` skill（提取论文图片，仅限有 arXiv ID 的论文）
+- `paper-analyze` skill（生成详细报告，仅限有 arXiv ID 的论文）

--- a/conf-papers/conf-papers.yaml
+++ b/conf-papers/conf-papers.yaml
@@ -1,0 +1,39 @@
+# conf-papers skill 专用配置
+
+# 感兴趣的关键词（用于从顶会论文中筛选）
+keywords:
+  - "large language model"
+  - "LLM"
+  - "pre-training"
+  - "fine-tuning"
+  - "foundation model"
+  - "transformer"
+  - "instruction tuning"
+  - "RLHF"
+  - "alignment"
+  - "reasoning"
+  - "chain-of-thought"
+  - "in-context learning"
+  - "scaling law"
+
+# 排除的关键词
+excluded_keywords:
+  - "3D"
+  - "review"
+  - "workshop"
+  - "survey"
+  - "tutorial"
+
+# 默认搜索年份（命令行参数可覆盖）
+default_year: 2025
+
+# 默认搜索的会议（命令行参数可覆盖，大小写均支持）
+# 可选: CVPR, ICCV, ECCV, ICLR, AAAI, NeurIPS, ICML
+default_conferences:
+  - "ICLR"
+  - "NeurIPS"
+  - "ICML"
+  - "CVPR"
+
+# 返回的论文数量
+top_n: 10

--- a/conf-papers/scripts/search_conf_papers.py
+++ b/conf-papers/scripts/search_conf_papers.py
@@ -1,0 +1,769 @@
+#!/usr/bin/env python3
+"""
+顶级会议论文搜索脚本
+使用 DBLP API 获取论文列表 + Semantic Scholar API 补充引用数和摘要
+支持 CVPR/ICCV/ECCV/ICLR/AAAI/NeurIPS/ICML 等顶会
+"""
+
+import json
+import os
+import re
+import sys
+import time
+import logging
+import argparse
+from typing import List, Dict, Optional, Tuple
+import urllib.request
+import urllib.parse
+
+logger = logging.getLogger(__name__)
+
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+    logger.warning("requests library not found, using urllib")
+
+# ---------------------------------------------------------------------------
+# 复用 search_arxiv.py 的评分函数
+# ---------------------------------------------------------------------------
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+_START_MY_DAY_SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(_SCRIPT_DIR)), 'start-my-day', 'scripts')
+if _START_MY_DAY_SCRIPTS not in sys.path:
+    sys.path.insert(0, _START_MY_DAY_SCRIPTS)
+
+from search_arxiv import (
+    calculate_relevance_score,
+    calculate_quality_score,
+    SCORE_MAX,
+    RELEVANCE_TITLE_KEYWORD_BOOST,
+    RELEVANCE_SUMMARY_KEYWORD_BOOST,
+    RELEVANCE_CATEGORY_MATCH_BOOST,
+    S2_RATE_LIMIT_WAIT,
+)
+
+# ---------------------------------------------------------------------------
+# 会议配置
+# ---------------------------------------------------------------------------
+# DBLP toc key 映射：用于 toc:db/conf/... 查询格式
+# value = (conf_path, toc_name_template)
+# toc_name_template 中 {year} 会被替换为实际年份
+# 对于无法用 toc 查询的会议（如 ECCV），使用 venue+year 备选查询
+DBLP_VENUES = {
+    "CVPR": {"toc": "conf/cvpr", "toc_name": "cvpr{year}"},
+    "ICCV": {"toc": "conf/iccv", "toc_name": "iccv{year}"},
+    "ECCV": {"toc": "conf/eccv", "toc_name": None, "venue_query": "ECCV"},  # ECCV toc 不可用，用 venue+year
+    "ICLR": {"toc": "conf/iclr", "toc_name": "iclr{year}"},
+    "AAAI": {"toc": "conf/aaai", "toc_name": "aaai{year}"},
+    "NeurIPS": {"toc": "conf/nips", "toc_name": "neurips{year}"},
+    "ICML": {"toc": "conf/icml", "toc_name": "icml{year}"},
+}
+
+# 会议 -> arXiv 分类映射（用于相关性评分中的分类匹配加分）
+VENUE_TO_CATEGORIES = {
+    "CVPR": ["cs.CV"],
+    "ICCV": ["cs.CV"],
+    "ECCV": ["cs.CV"],
+    "ICLR": ["cs.LG", "cs.AI"],
+    "ICML": ["cs.LG"],
+    "NeurIPS": ["cs.LG", "cs.AI", "cs.CL"],
+    "AAAI": ["cs.AI"],
+}
+
+# 评分权重（去掉新近性维度，因为年份由用户指定）
+WEIGHTS_CONF = {
+    'relevance': 0.40,
+    'popularity': 0.40,
+    'quality': 0.20,
+}
+
+# 热门度：高影响力引用满分基准
+POPULARITY_INFLUENTIAL_CITATION_FULL_SCORE = 100
+
+# Semantic Scholar 配置
+S2_API_URL = "https://api.semanticscholar.org/graph/v1/paper/search"
+S2_PAPER_URL = "https://api.semanticscholar.org/graph/v1/paper"
+S2_FIELDS = "title,abstract,citationCount,influentialCitationCount,externalIds,url,authors"
+S2_BATCH_URL = "https://api.semanticscholar.org/graph/v1/paper/batch"
+S2_API_KEY = None
+
+# DBLP API 配置
+DBLP_API_URL = "https://dblp.org/search/publ/api"
+
+# ---------------------------------------------------------------------------
+# DBLP 搜索
+# ---------------------------------------------------------------------------
+
+def search_dblp_conference(venue_key: str, year: int, max_results: int = 1000, max_retries: int = 3) -> List[Dict]:
+    """
+    调用 DBLP Search API 搜索指定会议和年份的论文
+
+    Args:
+        venue_key: 会议名称（如 "CVPR"）
+        year: 年份
+        max_results: 最大返回数量
+        max_retries: 最大重试次数
+
+    Returns:
+        论文列表，每篇包含 title, authors, dblp_url, year, conference
+    """
+    venue_info = DBLP_VENUES.get(venue_key)
+    if not venue_info:
+        logger.warning("[DBLP] Unknown venue: %s", venue_key)
+        return []
+
+    papers = []
+    hits_fetched = 0
+    batch_size = min(max_results, 1000)
+
+    # 构建查询列表：优先 toc 格式，备选 venue+year
+    queries_to_try = []
+    toc_name = venue_info.get("toc_name")
+    if toc_name:
+        toc_path = venue_info["toc"]
+        queries_to_try.append(f"toc:db/{toc_path}/{toc_name.format(year=year)}.bht:")
+    # 总是添加 venue+year 作为备选
+    venue_query = venue_info.get("venue_query", venue_key)
+    queries_to_try.append(f"venue:{venue_query} year:{year}")
+
+    for query_str in queries_to_try:
+        papers = []
+        hits_fetched = 0
+        query_failed = False
+
+        while hits_fetched < max_results:
+            params = {
+                "q": query_str,
+                "format": "json",
+                "h": batch_size,
+                "f": hits_fetched,
+            }
+
+            url = f"{DBLP_API_URL}?{urllib.parse.urlencode(params)}"
+            logger.info("[DBLP] Searching %s %d (offset=%d, query=%s)", venue_key, year, hits_fetched, query_str[:60])
+
+            success = False
+            for attempt in range(max_retries):
+                try:
+                    if HAS_REQUESTS:
+                        resp = requests.get(url, headers={"User-Agent": "ConfPapers/1.0"}, timeout=60)
+                        resp.raise_for_status()
+                        data = resp.json()
+                    else:
+                        req = urllib.request.Request(url, headers={"User-Agent": "ConfPapers/1.0"})
+                        with urllib.request.urlopen(req, timeout=60) as response:
+                            data = json.loads(response.read().decode('utf-8'))
+
+                    result = data.get("result", {})
+                    hits = result.get("hits", {})
+                    total = int(hits.get("@total", 0))
+                    hit_list = hits.get("hit", [])
+
+                    if not hit_list:
+                        logger.info("[DBLP] %s %d: no more results (total=%d)", venue_key, year, total)
+                        if papers:
+                            logger.info("[DBLP] %s %d: found %d papers", venue_key, year, len(papers))
+                            return papers
+                        # 0 results with this query, try next
+                        query_failed = True
+                        break
+
+                    for hit in hit_list:
+                        info = hit.get("info", {})
+                        title = info.get("title", "").rstrip(".")
+                        if not title:
+                            continue
+
+                        authors_info = info.get("authors", {}).get("author", [])
+                        if isinstance(authors_info, dict):
+                            authors_info = [authors_info]
+                        authors = [a.get("text", "") for a in authors_info if a.get("text")]
+
+                        paper = {
+                            "title": title,
+                            "authors": authors,
+                            "dblp_url": info.get("url", ""),
+                            "year": int(info.get("year", year)),
+                            "conference": venue_key,
+                            "doi": info.get("doi", ""),
+                            "venue": info.get("venue", venue_key),
+                            "source": "dblp",
+                        }
+                        papers.append(paper)
+
+                    hits_fetched += len(hit_list)
+                    success = True
+
+                    if hits_fetched >= total or hits_fetched >= max_results:
+                        break
+
+                    time.sleep(1)
+                    break  # 成功，退出重试循环
+
+                except Exception as e:
+                    logger.warning("[DBLP] Error (attempt %d/%d): %s", attempt + 1, max_retries, e)
+                    if attempt < max_retries - 1:
+                        wait_time = (2 ** attempt) * 3
+                        logger.info("[DBLP] Retrying in %d seconds...", wait_time)
+                        time.sleep(wait_time)
+                    else:
+                        logger.warning("[DBLP] Query failed for %s: %s", venue_key, query_str[:60])
+                        query_failed = True
+
+            if query_failed:
+                break
+            if hits_fetched >= max_results:
+                break
+
+        if papers:
+            logger.info("[DBLP] %s %d: found %d papers", venue_key, year, len(papers))
+            return papers
+        elif query_failed:
+            logger.info("[DBLP] Trying fallback query for %s %d...", venue_key, year)
+            continue
+
+    logger.warning("[DBLP] %s %d: no papers found with any query", venue_key, year)
+    return []
+
+
+def search_all_conferences(year: int, venues: List[str], max_per_venue: int = 1000) -> List[Dict]:
+    """
+    遍历所有会议搜索论文，合并去重
+
+    Args:
+        year: 年份
+        venues: 会议列表
+        max_per_venue: 每个会议最大拉取数
+
+    Returns:
+        去重后的论文列表
+    """
+    all_papers = []
+    seen_titles = set()
+
+    for venue in venues:
+        logger.info("=" * 50)
+        logger.info("Searching %s %d...", venue, year)
+
+        papers = search_dblp_conference(venue, year, max_results=max_per_venue)
+
+        for p in papers:
+            title_norm = re.sub(r'[^a-z0-9\s]', '', p['title'].lower()).strip()
+            if title_norm not in seen_titles:
+                seen_titles.add(title_norm)
+                all_papers.append(p)
+
+        logger.info("Total unique papers so far: %d", len(all_papers))
+        time.sleep(1)  # 会议间延迟
+
+    return all_papers
+
+
+# ---------------------------------------------------------------------------
+# 两阶段过滤：第一阶段 - 轻量关键词过滤
+# ---------------------------------------------------------------------------
+
+def load_conf_papers_config(config_path: str) -> Dict:
+    """
+    从 conf-papers.yaml 加载专用配置。
+
+    Args:
+        config_path: conf-papers.yaml 路径
+
+    Returns:
+        {keywords: [...], excluded_keywords: [...], default_year, default_conferences, top_n}
+    """
+    import yaml
+
+    try:
+        with open(config_path, 'r', encoding='utf-8') as f:
+            cp = yaml.safe_load(f) or {}
+    except Exception as e:
+        logger.error("Error loading conf-papers config: %s", e)
+        cp = {}
+
+    return {
+        'keywords': cp.get('keywords', []),
+        'excluded_keywords': cp.get('excluded_keywords', []),
+        'default_year': cp.get('default_year'),
+        'default_conferences': cp.get('default_conferences'),
+        'top_n': cp.get('top_n', 10),
+    }
+
+
+def lightweight_keyword_filter(papers: List[Dict], cp_config: Dict) -> List[Dict]:
+    """
+    第一阶段：仅凭标题关键词做轻量相关性过滤
+    使用 conf-papers.yaml 中的关键词
+
+    Args:
+        papers: DBLP 拉取的全部论文
+        cp_config: conf-papers 专用配置
+
+    Returns:
+        通过关键词过滤的论文列表
+    """
+    # 收集所有关键词（小写）
+    all_keywords = set(kw.lower() for kw in cp_config['keywords'])
+    excluded_lower = set(kw.lower() for kw in cp_config['excluded_keywords'])
+
+    filtered = []
+    for paper in papers:
+        title_lower = paper['title'].lower()
+
+        # 检查排除关键词
+        if any(ex in title_lower for ex in excluded_lower):
+            continue
+
+        # 检查是否匹配任何研究关键词
+        matched = False
+        matched_keywords = []
+        for kw in all_keywords:
+            if kw in title_lower:
+                matched = True
+                matched_keywords.append(kw)
+
+        if matched:
+            paper['_preliminary_keywords'] = matched_keywords
+            filtered.append(paper)
+
+    logger.info("[Filter] Lightweight keyword filter: %d -> %d papers", len(papers), len(filtered))
+    return filtered
+
+
+# ---------------------------------------------------------------------------
+# Semantic Scholar 补充
+# ---------------------------------------------------------------------------
+
+def title_similarity(a: str, b: str) -> float:
+    """
+    归一化标题比较，用于 S2 匹配验证
+
+    Returns:
+        0.0-1.0 之间的相似度分数
+    """
+    def normalize(s):
+        return re.sub(r'[^a-z0-9\s]', '', s.lower()).strip()
+
+    a_norm = normalize(a)
+    b_norm = normalize(b)
+
+    if not a_norm or not b_norm:
+        return 0.0
+
+    # 使用词级别的 Jaccard 相似度
+    words_a = set(a_norm.split())
+    words_b = set(b_norm.split())
+
+    if not words_a or not words_b:
+        return 0.0
+
+    intersection = words_a & words_b
+    union = words_a | words_b
+
+    return len(intersection) / len(union)
+
+
+def enrich_with_semantic_scholar(papers: List[Dict], max_retries: int = 3) -> List[Dict]:
+    """
+    使用 S2 搜索 API 按标题补充 abstract/citations/arxiv_id
+    分批处理，每批之间有间隔以避免限流
+
+    Args:
+        papers: 需要补充信息的论文列表
+        max_retries: 每次请求的最大重试次数
+
+    Returns:
+        补充信息后的论文列表
+    """
+    if not HAS_REQUESTS:
+        logger.warning("[S2] requests library not available, skipping enrichment")
+        for p in papers:
+            p['abstract'] = None
+            p['citationCount'] = 0
+            p['influentialCitationCount'] = 0
+            p['s2_matched'] = False
+        return papers
+
+    headers = {"User-Agent": "ConfPapers/1.0"}
+    if S2_API_KEY:
+        headers["x-api-key"] = S2_API_KEY
+
+    enriched_count = 0
+    total = len(papers)
+
+    for i, paper in enumerate(papers):
+        title = paper.get('title', '')
+        if not title:
+            paper['abstract'] = None
+            paper['citationCount'] = 0
+            paper['influentialCitationCount'] = 0
+            paper['s2_matched'] = False
+            continue
+
+        if (i + 1) % 10 == 0:
+            logger.info("[S2] Progress: %d/%d enriched so far: %d", i + 1, total, enriched_count)
+
+        params = {
+            "query": title,
+            "limit": 3,
+            "fields": S2_FIELDS,
+        }
+
+        matched = False
+        for attempt in range(max_retries):
+            try:
+                response = requests.get(S2_API_URL, params=params, headers=headers, timeout=15)
+                if response.status_code == 429:
+                    wait = S2_RATE_LIMIT_WAIT
+                    logger.warning("[S2] Rate limit hit, waiting %d seconds...", wait)
+                    time.sleep(wait)
+                    continue
+                response.raise_for_status()
+                data = response.json()
+
+                results = data.get("data", [])
+                if not results:
+                    break
+
+                best_match = None
+                best_sim = 0.0
+                for r in results:
+                    sim = title_similarity(title, r.get('title', ''))
+                    if sim > best_sim:
+                        best_sim = sim
+                        best_match = r
+
+                if best_match and best_sim >= 0.6:
+                    paper['abstract'] = best_match.get('abstract')
+                    paper['citationCount'] = best_match.get('citationCount') or 0
+                    paper['influentialCitationCount'] = best_match.get('influentialCitationCount') or 0
+                    paper['s2_url'] = best_match.get('url', '')
+
+                    ext_ids = best_match.get('externalIds', {})
+                    if ext_ids:
+                        paper['arxiv_id'] = ext_ids.get('ArXiv')
+                        paper['doi'] = paper.get('doi') or ext_ids.get('DOI', '')
+
+                    if not paper.get('authors') and best_match.get('authors'):
+                        paper['authors'] = [a.get('name', '') for a in best_match['authors'] if a.get('name')]
+
+                    paper['s2_matched'] = True
+                    paper['s2_title_similarity'] = round(best_sim, 2)
+                    enriched_count += 1
+                    matched = True
+
+                break
+
+            except Exception as e:
+                error_msg = str(e)
+                is_rate_limit = "429" in error_msg or "Too Many Requests" in error_msg
+                if attempt < max_retries - 1:
+                    if is_rate_limit:
+                        time.sleep(S2_RATE_LIMIT_WAIT)
+                    else:
+                        time.sleep(2 ** attempt)
+                else:
+                    logger.debug("[S2] Failed to enrich: %s", title[:50])
+
+        if not matched:
+            paper['abstract'] = None
+            paper['citationCount'] = 0
+            paper['influentialCitationCount'] = 0
+            paper['s2_matched'] = False
+
+        # 关键：每次请求后等待 1 秒避免 429
+        # S2 免费层约 1 req/sec
+        time.sleep(1.0)
+
+    logger.info("[S2] Enrichment complete: %d/%d papers enriched", enriched_count, total)
+    return papers
+
+
+# ---------------------------------------------------------------------------
+# 评分
+# ---------------------------------------------------------------------------
+
+def calculate_popularity_score(paper: Dict) -> float:
+    """
+    基于 influentialCitationCount 和 citationCount 计算热门度
+
+    Args:
+        paper: 论文信息
+
+    Returns:
+        热门度评分 (0-SCORE_MAX)
+    """
+    inf_cit = paper.get('influentialCitationCount', 0)
+    cit = paper.get('citationCount', 0)
+
+    if inf_cit > 0:
+        # 高影响力引用：归一化到 0-SCORE_MAX
+        score = min(inf_cit / (POPULARITY_INFLUENTIAL_CITATION_FULL_SCORE / SCORE_MAX), SCORE_MAX)
+    elif cit > 0:
+        # 普通引用：更保守的评分
+        score = min(cit / 200 * SCORE_MAX, SCORE_MAX * 0.7)
+    else:
+        score = 0.0
+
+    return score
+
+
+def filter_and_score_papers(papers: List[Dict], cp_config: Dict, top_n: int = 10) -> List[Dict]:
+    """
+    对论文进行完整的三维评分（相关性+热门度+质量），排序取 top N
+    使用 conf-papers.yaml 的关键词构建虚拟 domain 用于评分
+
+    Args:
+        papers: 论文列表（已经过 S2 补充）
+        cp_config: conf-papers 专用配置
+        top_n: 返回前 N 篇
+
+    Returns:
+        评分排序后的论文列表
+    """
+    # 构建虚拟 domain 供 calculate_relevance_score 使用
+    domains = {
+        "conf_papers": {
+            "keywords": cp_config['keywords'],
+            "arxiv_categories": ["cs.AI", "cs.CL", "cs.LG"],
+        }
+    }
+    excluded_keywords = cp_config['excluded_keywords']
+
+    scored_papers = []
+
+    for paper in papers:
+        # 为了复用 calculate_relevance_score，需要为顶会论文补充 categories
+        # 使用会议到分类的映射
+        venue = paper.get('conference', '')
+        venue_categories = VENUE_TO_CATEGORIES.get(venue, [])
+        paper['categories'] = venue_categories
+
+        # 用 abstract 替代 summary（兼容 calculate_relevance_score）
+        if paper.get('abstract') and not paper.get('summary'):
+            paper['summary'] = paper['abstract']
+
+        # 计算相关性
+        relevance, matched_domain, matched_keywords = calculate_relevance_score(
+            paper, domains, excluded_keywords
+        )
+
+        if relevance == 0:
+            continue
+
+        # 计算热门度
+        popularity = calculate_popularity_score(paper)
+
+        # 计算质量
+        summary = paper.get('summary', '') or paper.get('abstract', '') or ''
+        quality = calculate_quality_score(summary)
+
+        # 计算综合评分（三维度）
+        normalized = {
+            'relevance': (relevance / SCORE_MAX) * 10,
+            'popularity': (popularity / SCORE_MAX) * 10,
+            'quality': (quality / SCORE_MAX) * 10,
+        }
+        final_score = sum(normalized[k] * WEIGHTS_CONF[k] for k in WEIGHTS_CONF)
+        final_score = round(final_score, 2)
+
+        paper['scores'] = {
+            'relevance': round(relevance, 2),
+            'popularity': round(popularity, 2),
+            'quality': round(quality, 2),
+            'recommendation': final_score,
+        }
+        paper['matched_domain'] = matched_domain
+        paper['matched_keywords'] = matched_keywords
+
+        scored_papers.append(paper)
+
+    # 按推荐评分排序
+    scored_papers.sort(key=lambda x: x['scores']['recommendation'], reverse=True)
+
+    logger.info("[Score] %d papers scored, returning top %d", len(scored_papers), top_n)
+    return scored_papers[:top_n]
+
+
+# ---------------------------------------------------------------------------
+# 主函数
+# ---------------------------------------------------------------------------
+
+def main():
+    # 默认配置路径：脚本所在 skill 目录下的 conf-papers.yaml
+    default_config = os.path.join(os.path.dirname(_SCRIPT_DIR), 'conf-papers.yaml')
+
+    parser = argparse.ArgumentParser(description='Search top conference papers via DBLP + Semantic Scholar')
+    parser.add_argument('--config', type=str,
+                        default=default_config,
+                        help='Path to conf-papers.yaml config file')
+    parser.add_argument('--output', type=str, default='conf_papers_filtered.json',
+                        help='Output JSON file path')
+    parser.add_argument('--year', type=int, default=None,
+                        help='Conference year to search (default: from config)')
+    parser.add_argument('--conferences', type=str, default=None,
+                        help='Comma-separated conference names (default: from config)')
+    parser.add_argument('--top-n', type=int, default=None,
+                        help='Number of top papers to return (default: from config)')
+    parser.add_argument('--max-per-venue', type=int, default=1000,
+                        help='Max papers to fetch per venue from DBLP')
+    parser.add_argument('--skip-enrichment', action='store_true',
+                        help='Skip Semantic Scholar enrichment (for debugging)')
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s [%(levelname)s] %(message)s',
+        datefmt='%H:%M:%S',
+        stream=sys.stderr,
+    )
+
+    if not os.path.exists(args.config):
+        logger.error("配置文件不存在: %s", args.config)
+        return 1
+
+    logger.info("Loading conf-papers config from: %s", args.config)
+    cp_config = load_conf_papers_config(args.config)
+    logger.info("Config: %d keywords, %d excluded",
+                len(cp_config['keywords']), len(cp_config['excluded_keywords']))
+
+    # 确定年份：命令行 > 配置 > 报错
+    year = args.year or cp_config.get('default_year')
+    if not year:
+        logger.error("未指定搜索年份。请通过 --year 参数或配置文件 conf_papers.default_year 设置。")
+        return 1
+
+    # 确定 top_n：命令行 > 配置 > 默认 10
+    top_n = args.top_n or cp_config.get('top_n', 10)
+
+    # 确定要搜索的会议：命令行 > 配置 > 全部 7 个
+    if args.conferences:
+        venues = [v.strip() for v in args.conferences.split(',')]
+    elif cp_config.get('default_conferences'):
+        venues = list(cp_config['default_conferences'])
+    else:
+        venues = list(DBLP_VENUES.keys())
+
+    # 验证会议名（大小写不敏感匹配）
+    venue_name_map = {k.upper(): k for k in DBLP_VENUES}
+    valid_venues = []
+    for v in venues:
+        canonical = venue_name_map.get(v.upper())
+        if canonical:
+            valid_venues.append(canonical)
+        else:
+            logger.warning("Unknown conference: %s (available: %s)", v, ', '.join(DBLP_VENUES.keys()))
+    venues = valid_venues
+
+    if not venues:
+        logger.error("No valid conferences specified")
+        return 1
+
+    logger.info("Conferences: %s", ', '.join(venues))
+    logger.info("Year: %d", year)
+
+    # ========== 第一步：DBLP 搜索 ==========
+    logger.info("=" * 70)
+    logger.info("Step 1: Searching papers from DBLP")
+    logger.info("=" * 70)
+
+    all_papers = search_all_conferences(year, venues, max_per_venue=args.max_per_venue)
+    total_found = len(all_papers)
+    logger.info("Total papers found from DBLP: %d", total_found)
+
+    if not all_papers:
+        logger.warning("No papers found from DBLP!")
+        # 输出空结果
+        output = {
+            "year": year,
+            "conferences_searched": venues,
+            "total_found": 0,
+            "total_enriched": 0,
+            "total_unique": 0,
+            "top_papers": [],
+        }
+        with open(args.output, 'w', encoding='utf-8') as f:
+            json.dump(output, f, ensure_ascii=False, indent=2)
+        print(json.dumps(output, ensure_ascii=False, indent=2))
+        return 0
+
+    # ========== 第二步：轻量关键词过滤 ==========
+    logger.info("=" * 70)
+    logger.info("Step 2: Lightweight keyword filtering")
+    logger.info("=" * 70)
+
+    filtered_papers = lightweight_keyword_filter(all_papers, cp_config)
+    total_filtered = len(filtered_papers)
+
+    if not filtered_papers:
+        logger.warning("No papers passed keyword filter!")
+        output = {
+            "year": year,
+            "conferences_searched": venues,
+            "total_found": total_found,
+            "total_enriched": 0,
+            "total_unique": 0,
+            "top_papers": [],
+        }
+        with open(args.output, 'w', encoding='utf-8') as f:
+            json.dump(output, f, ensure_ascii=False, indent=2)
+        print(json.dumps(output, ensure_ascii=False, indent=2))
+        return 0
+
+    # ========== 第三步：Semantic Scholar 补充 ==========
+    total_enriched = 0
+    if not args.skip_enrichment:
+        logger.info("=" * 70)
+        logger.info("Step 3: Enriching with Semantic Scholar (%d papers)", len(filtered_papers))
+        logger.info("=" * 70)
+
+        filtered_papers = enrich_with_semantic_scholar(filtered_papers)
+        total_enriched = sum(1 for p in filtered_papers if p.get('s2_matched'))
+    else:
+        logger.info("Skipping Semantic Scholar enrichment (--skip-enrichment)")
+
+    # ========== 第四步：评分排序 ==========
+    logger.info("=" * 70)
+    logger.info("Step 4: Scoring and ranking")
+    logger.info("=" * 70)
+
+    top_papers = filter_and_score_papers(filtered_papers, cp_config, top_n=top_n)
+
+    # 清理输出中的内部字段
+    for p in top_papers:
+        p.pop('_preliminary_keywords', None)
+        p.pop('s2_matched', None)
+        p.pop('s2_title_similarity', None)
+        p.pop('categories', None)
+        p.pop('summary', None)  # 保留 abstract，去掉重复的 summary
+
+    # 准备输出
+    output = {
+        "year": args.year,
+        "conferences_searched": venues,
+        "total_found": total_found,
+        "total_filtered": total_filtered,
+        "total_enriched": total_enriched,
+        "top_papers": top_papers,
+    }
+
+    with open(args.output, 'w', encoding='utf-8') as f:
+        json.dump(output, f, ensure_ascii=False, indent=2, default=str)
+
+    logger.info("Results saved to: %s", args.output)
+    logger.info("Top %d papers:", len(top_papers))
+    for i, p in enumerate(top_papers, 1):
+        cit = p.get('citationCount', 0)
+        logger.info("  %d. [%s] %s... (Score: %s, Citations: %d)",
+                     i, p.get('conference', '?'), p.get('title', 'N/A')[:50],
+                     p['scores']['recommendation'], cit)
+
+    print(json.dumps(output, ensure_ascii=False, indent=2, default=str))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
新增 conf-papers skill，支持搜索 CVPR/ICCV/ECCV/ICLR/AAAI/NeurIPS/ICML 等顶级会议论文：
- 基于 DBLP API 搜索 + Semantic Scholar API 补充引用和摘要
- 独立配置文件 conf-papers.yaml（关键词、排除词、默认年份/会议）
- 两阶段过滤：标题关键词轻量筛选 → S2 补充 → 三维评分
- 会议名大小写不敏感
- 更新 README：新增更新日志、功能说明、目录结构

   变更文件
  - `conf-papers/scripts/search_conf_papers.py` — 主脚本（DBLP 搜索 + S2 补充 + 评分）
  - `conf-papers/SKILL.md` — Skill 定义和工作流
  - `conf-papers/conf-papers.yaml` — 独立配置文件
  - `README.md` — 新增更新日志、conf-papers 功能说明和目录结构

   Test plan
  - [ ] `python scripts/search_conf_papers.py --year 2024 --conferences ICLR --skip-enrichment --top-n 5` 验证 DBLP 搜索
  - [ ] `python scripts/search_conf_papers.py --year 2024 --conferences ICLR --top-n 3` 验证 S2 补充
  - [ ] `/conf-papers 2024 ICLR,CVPR` 验证完整工作流
  - [ ] 确认不影响已有 skill（start-my-day、paper-analyze 等）