### PR TITLE
feat(web): add OrcaRouter as a named provider option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,41 @@ ANTHROPIC_BASE_URL=https://api.anthropic.com
 
 > 优先级：`data/api_settings.json` > 环境变量 > 代码默认值
 
+### 使用 OrcaRouter 作为 AI 服务提供商
+
+也可以把 Web 应用的 AI 能力指向 [OrcaRouter](https://www.orcarouter.ai)——一个统一模型网关，在同一个端点上提供网关级、零信任的 AI 代理安全防护：对每条提示词/响应进行筛查，并以默认拒绝的方式治理每一个工具调用，无需修改任何应用代码。
+
+**方式 A：设置页选择 OrcaRouter**
+
+在设置页（`/settings`）的"服务提供商"下拉里选择 **OrcaRouter**，会自动填入：
+
+```json
+{
+  "model": "orcarouter/auto",
+  "api_key": "sk-orca-你的密钥",
+  "base_url": "https://api.orcarouter.ai"
+}
+```
+
+**方式 B：`data/api_settings.json`**
+
+```json
+{
+  "model": "orcarouter/auto",
+  "api_key": "sk-orca-your-key",
+  "base_url": "https://api.orcarouter.ai"
+}
+```
+
+**方式 C：环境变量**
+
+```bash
+ANTHROPIC_API_KEY=sk-orca-your-key
+ANTHROPIC_BASE_URL=https://api.orcarouter.ai
+```
+
+OrcaRouter 兼容 Anthropic Messages API（`/v1/messages`），SDK 会自动拼接 `/v1` 路径；`orcarouter/auto` 为智能路由模型。在 [orcarouter.ai](https://www.orcarouter.ai) 获取密钥。
+
 ```bash
 # 5. 启动 Web 应用
 cd web

--- a/README_en.md
+++ b/README_en.md
@@ -167,6 +167,41 @@ Set `DEFAULT_API_KEY` and `DEFAULT_BASE_URL` constants in `web/src/lib/anthropic
 
 > Priority: `data/api_settings.json` > Environment variables > Code defaults
 
+### Using OrcaRouter as your AI provider
+
+You can also point the web app's AI features at [OrcaRouter](https://www.orcarouter.ai) — a unified model gateway. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+**Option A: select OrcaRouter in Settings**
+
+In the Settings page (`/settings`), choose **OrcaRouter** from the "Provider" dropdown. It fills in:
+
+```json
+{
+  "model": "orcarouter/auto",
+  "api_key": "sk-orca-your-key",
+  "base_url": "https://api.orcarouter.ai"
+}
+```
+
+**Option B: `data/api_settings.json`**
+
+```json
+{
+  "model": "orcarouter/auto",
+  "api_key": "sk-orca-your-key",
+  "base_url": "https://api.orcarouter.ai"
+}
+```
+
+**Option C: environment variables**
+
+```bash
+ANTHROPIC_API_KEY=sk-orca-your-key
+ANTHROPIC_BASE_URL=https://api.orcarouter.ai
+```
+
+OrcaRouter is compatible with the Anthropic Messages API (`/v1/messages`) — the SDK appends the `/v1` path automatically. `orcarouter/auto` is the smart-routing model. Get a key at [orcarouter.ai](https://www.orcarouter.ai).
+
 ```bash
 # 5. Start the Web app
 cd web

--- a/web/README.md
+++ b/web/README.md
@@ -77,6 +77,34 @@ Set `DEFAULT_API_KEY` and `DEFAULT_BASE_URL` constants in the source code (not r
 
 Priority: `data/api_settings.json` > Environment variables > Code defaults.
 
+### Using OrcaRouter as your AI provider
+
+You can also point the web app's AI features at [OrcaRouter](https://www.orcarouter.ai) — a unified model gateway. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+**Option A: select OrcaRouter in Settings**
+
+In the Settings page (`/settings`), choose **OrcaRouter** from the "Provider" dropdown. It fills in:
+
+```json
+{
+  "model": "orcarouter/auto",
+  "api_key": "sk-orca-your-key",
+  "base_url": "https://api.orcarouter.ai"
+}
+```
+
+**Option B: `data/api_settings.json`**
+
+```json
+{
+  "model": "orcarouter/auto",
+  "api_key": "sk-orca-your-key",
+  "base_url": "https://api.orcarouter.ai"
+}
+```
+
+OrcaRouter is compatible with the Anthropic Messages API (`/v1/messages`) — the SDK appends the `/v1` path automatically. `orcarouter/auto` is the smart-routing model. Get a key at [orcarouter.ai](https://www.orcarouter.ai).
+
 ### 3. Configure Research Interests
 
 Copy the example config at the project root:

--- a/web/README.zh.md
+++ b/web/README.zh.md
@@ -77,6 +77,34 @@ ANTHROPIC_BASE_URL=https://api.anthropic.com
 
 优先级：`data/api_settings.json` > 环境变量 > 代码默认值。
 
+### 使用 OrcaRouter 作为 AI 服务提供商
+
+也可以把 Web 应用的 AI 能力指向 [OrcaRouter](https://www.orcarouter.ai)——一个统一模型网关，在同一个端点上提供网关级、零信任的 AI 代理安全防护：对每条提示词/响应进行筛查，并以默认拒绝的方式治理每一个工具调用，无需修改任何应用代码。
+
+**方式 A：设置页选择 OrcaRouter**
+
+在设置页（`/settings`）的"服务提供商"下拉里选择 **OrcaRouter**，会自动填入：
+
+```json
+{
+  "model": "orcarouter/auto",
+  "api_key": "sk-orca-你的密钥",
+  "base_url": "https://api.orcarouter.ai"
+}
+```
+
+**方式 B：`data/api_settings.json`**
+
+```json
+{
+  "model": "orcarouter/auto",
+  "api_key": "sk-orca-your-key",
+  "base_url": "https://api.orcarouter.ai"
+}
+```
+
+OrcaRouter 兼容 Anthropic Messages API（`/v1/messages`），SDK 会自动拼接 `/v1` 路径；`orcarouter/auto` 为智能路由模型。在 [orcarouter.ai](https://www.orcarouter.ai) 获取密钥。
+
 ### 3. 配置研究兴趣
 
 在项目根目录复制示例配置：

--- a/web/src/app/api/settings/route.ts
+++ b/web/src/app/api/settings/route.ts
@@ -12,6 +12,7 @@ export async function GET() {
       claude: {
         model: apiSettings.model || "claude-sonnet-4-6",
         api_key: apiSettings.api_key || "",
+        base_url: apiSettings.base_url || "https://api.anthropic.com",
         max_tokens: 4096,
       },
       research,

--- a/web/src/app/settings/page.tsx
+++ b/web/src/app/settings/page.tsx
@@ -11,6 +11,38 @@ const MODEL_OPTIONS = [
   "claude-haiku-4-5-20251001",
 ];
 
+const ORCA_MODEL_OPTIONS = [
+  "orcarouter/auto",
+  "orcarouter/fusion",
+  "orcarouter/fusion-flash",
+  "orcarouter/fusion-mini",
+];
+
+// Provider presets. Selecting a preset fills base_url + model and keeps the
+// entered API key. "anthropic" is the built-in default; "orcarouter" points
+// at the OrcaRouter gateway (https://api.orcarouter.ai), which is compatible
+// with the Anthropic Messages API used by this app.
+const PROVIDER_PRESETS = {
+  anthropic: {
+    label: "Anthropic",
+    base_url: "https://api.anthropic.com",
+    model: "claude-sonnet-4-6",
+  },
+  orcarouter: {
+    label: "OrcaRouter",
+    base_url: "https://api.orcarouter.ai",
+    model: "orcarouter/auto",
+  },
+} as const;
+
+type ProviderPresetKey = keyof typeof PROVIDER_PRESETS;
+
+function presetKeyFor(claude: AppSettings["claude"]): ProviderPresetKey {
+  const base = (claude.base_url || "").replace(/\/+$/, "");
+  if (base === "https://api.orcarouter.ai") return "orcarouter";
+  return "anthropic";
+}
+
 export default function SettingsPage() {
   const [settings, setSettings] = useState<AppSettings | null>(null);
   const [loading, setLoading] = useState(true);
@@ -123,6 +155,43 @@ export default function SettingsPage() {
         <p className="text-xs text-[var(--text-secondary)] mb-3">
           {t("settings.claudeConfigDesc")}
         </p>
+        <Field label={t("settings.providerSelection")}>
+          <select
+            value={presetKeyFor(settings.claude)}
+            onChange={(e) => {
+              const preset = PROVIDER_PRESETS[e.target.value as ProviderPresetKey];
+              setSettings({
+                ...settings,
+                claude: {
+                  ...settings.claude,
+                  base_url: preset.base_url,
+                  model: preset.model,
+                },
+              });
+            }}
+            className="w-full bg-[var(--bg-primary)] border border-[var(--border)] rounded px-3 py-2 text-sm lg:text-base"
+          >
+            {(Object.keys(PROVIDER_PRESETS) as ProviderPresetKey[]).map((k) => (
+              <option key={k} value={k}>
+                {PROVIDER_PRESETS[k].label}
+              </option>
+            ))}
+          </select>
+        </Field>
+        <Field label={t("settings.baseUrlLabel")}>
+          <input
+            type="text"
+            value={settings.claude.base_url}
+            onChange={(e) =>
+              setSettings({
+                ...settings,
+                claude: { ...settings.claude, base_url: e.target.value },
+              })
+            }
+            className="w-full bg-[var(--bg-primary)] border border-[var(--border)] rounded px-3 py-2 text-sm lg:text-base"
+            placeholder="https://api.anthropic.com"
+          />
+        </Field>
         <Field label={t("settings.modelSelection")}>
           <select
             value={settings.claude.model}
@@ -134,11 +203,17 @@ export default function SettingsPage() {
             }
             className="w-full bg-[var(--bg-primary)] border border-[var(--border)] rounded px-3 py-2 text-sm lg:text-base"
           >
-            {MODEL_OPTIONS.map((m) => (
-              <option key={m} value={m}>
-                {m}
-              </option>
-            ))}
+            {presetKeyFor(settings.claude) === "orcarouter"
+              ? ORCA_MODEL_OPTIONS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))
+              : MODEL_OPTIONS.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
           </select>
         </Field>
         <Field label={t("settings.apiKeyLabel")}>

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -61,6 +61,8 @@ const translations: Record<Language, Record<string, string>> = {
     // Settings page
     "settings.claudeConfig": "Claude 模型配置",
     "settings.claudeConfigDesc": "已内置默认 API，无需配置即可使用。以下选项仅用于自定义覆盖。",
+    "settings.providerSelection": "服务提供商",
+    "settings.baseUrlLabel": "API 地址 (Base URL)",
     "settings.modelSelection": "模型选择",
     "settings.apiKeyLabel": "API Key（留空使用默认）",
     "settings.apiKeyPlaceholder": "留空使用内置默认 API",
@@ -141,6 +143,8 @@ const translations: Record<Language, Record<string, string>> = {
     // Settings page
     "settings.claudeConfig": "Claude Model Configuration",
     "settings.claudeConfigDesc": "Built-in default API is ready to use. Options below are for custom overrides only.",
+    "settings.providerSelection": "Provider",
+    "settings.baseUrlLabel": "API Base URL",
     "settings.modelSelection": "Model",
     "settings.apiKeyLabel": "API Key (leave empty for default)",
     "settings.apiKeyPlaceholder": "Leave empty to use built-in default API",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -107,6 +107,7 @@ export interface AppSettings {
   claude: {
     model: string;
     api_key: string;
+    base_url: string;
     max_tokens: number;
   };
   research: ResearchConfig;


### PR DESCRIPTION
## Summary

This PR adds **[OrcaRouter](https://www.orcarouter.ai)** as a named provider option in the web app, and documents routing the app's AI features through the OrcaRouter gateway.

The web app already drives all AI calls (`/api/papers`, `/api/papers/[id]/analyze`, `/api/papers/filter`, `/api/preferences/update`) through a settings-driven Anthropic-compatible client (`web/src/lib/anthropic.ts`), so no transport changes are needed — the gateway is plug-and-play.

### Changes

- **`web/src/app/settings/page.tsx`** — new "Provider" selector with an **OrcaRouter** preset that fills `base_url=https://api.orcarouter.ai` + `model=orcarouter/auto`, plus an editable Base URL field and an OrcaRouter model list (`orcarouter/auto`, `fusion`, `fusion-flash`, `fusion-mini`).
- **`web/src/app/api/settings/route.ts`** — surface `base_url` in the settings GET (it was already persisted on PUT).
- **`web/src/lib/types.ts`** — add `base_url` to the `AppSettings.claude` shape.
- **`web/src/lib/i18n.ts`** — zh/en labels for the new fields.
- **`README.md` / `README_en.md` / `web/README.md` / `web/README.zh.md`** — "Using OrcaRouter as your AI provider" sections (settings preset, `data/api_settings.json`, and env-var options).

OrcaRouter is compatible with the Anthropic Messages API (`/v1/messages`); the SDK appends the `/v1` path automatically. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

### Verification

- `npx tsc --noEmit` — no new errors (only pre-existing `RouteContext` gaps in untouched route files).
- `npx next build` — succeeds.
- `npx eslint` on changed files — clean.
- L3 live test: `@anthropic-ai/sdk` `messages.create({ model: "orcarouter/auto" })` with `baseURL=https://api.orcarouter.ai` returned HTTP 200 `ORCA-LIVE-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.
